### PR TITLE
KeyError  if there's no ~/httproxy/config

### DIFF
--- a/src/httproxy.py
+++ b/src/httproxy.py
@@ -394,6 +394,10 @@ def handle_configuration():
         os.path.expanduser(os.sep.join(('~', '.httproxy', 'config'))),
         cmdline_args.get('--configfile') or '',
     ])
+    
+    if not 'main' in inifile.sections():
+        inifile.add_section('main')
+        
     iniconf = dict(inifile['main'])
     for opt in iniconf:
         try:


### PR DESCRIPTION
When  ~/httproxy/config is not present a KeyError 'main' is raised. This happens in `handle_config`:iniconf=dict(inifile['main']). Numerous ways to solve this of course, I've just added a check to see if 'main' is a section in inifile, and if not - add the section.

regards

/rune
